### PR TITLE
fix: Resolve frontend Docker build failures

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+.git
+*.md
+.env*
+.DS_Store
+coverage
+test-results

--- a/frontend/app/admin/content/page.tsx
+++ b/frontend/app/admin/content/page.tsx
@@ -36,7 +36,7 @@ import {
 import { PermissionName } from "@/lib/permissions";
 import { InstanceSettings } from "@/components/admin/instance-settings";
 import { UserManagement } from "@/components/admin/user-management";
-import { Navbar } from "@/components/dashboard/navbar";
+import { NavbarWithSuspense as Navbar } from "@/components/dashboard/navbar-wrapper";
 import { Footer } from "@/components/dashboard/footer";
 import { FrbrEditor } from "@/components/admin/frbr-editor";
 import { Button } from "@/components/ui/button";

--- a/frontend/app/admin/groups/page.tsx
+++ b/frontend/app/admin/groups/page.tsx
@@ -30,7 +30,7 @@ import {
   Image as ImageIcon,
 } from "lucide-react";
 import { GroupManagement } from "@/components/admin/group-management";
-import { Navbar } from "@/components/dashboard/navbar";
+import { NavbarWithSuspense as Navbar } from "@/components/dashboard/navbar-wrapper";
 import { Footer } from "@/components/dashboard/footer";
 import { cn } from "@/lib/utils";
 import type { LucideIcon } from "lucide-react";

--- a/frontend/app/admin/settings/page.tsx
+++ b/frontend/app/admin/settings/page.tsx
@@ -39,7 +39,7 @@ import {
 import { PermissionName } from "@/lib/permissions";
 import { InstanceSettings } from "@/components/admin/instance-settings";
 import { UserManagement } from "@/components/admin/user-management";
-import { Navbar } from "@/components/dashboard/navbar";
+import { NavbarWithSuspense as Navbar } from "@/components/dashboard/navbar-wrapper";
 import { Footer } from "@/components/dashboard/footer";
 import { FrbrEditor } from "@/components/admin/frbr-editor";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";

--- a/frontend/app/collection/page.tsx
+++ b/frontend/app/collection/page.tsx
@@ -18,7 +18,7 @@
 import { useState, useMemo, useCallback, Suspense, useEffect } from "react";
 import { SlidersHorizontal, Search, Library as LibraryIcon, BookOpen } from "lucide-react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
-import { Navbar } from "@/components/dashboard/navbar";
+import { NavbarWithSuspense as Navbar } from "@/components/dashboard/navbar-wrapper";
 import { SidebarFilters } from "@/components/collection/sidebar-filters";
 import type { ActiveFilter } from "@/components/collection/filter-bar";
 import { FilterBar } from "@/components/collection/filter-bar";

--- a/frontend/app/item/[id]/page.tsx
+++ b/frontend/app/item/[id]/page.tsx
@@ -18,7 +18,7 @@
 import { use } from "react";
 import { useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
-import { Navbar } from "@/components/dashboard/navbar";
+import { NavbarWithSuspense as Navbar } from "@/components/dashboard/navbar-wrapper";
 import { HeroBanner } from "@/components/item/hero-banner";
 import { ItemSidebar } from "@/components/item/item-sidebar";
 import { ItemHeader } from "@/components/item/item-header";

--- a/frontend/app/legal/privacy/page.tsx
+++ b/frontend/app/legal/privacy/page.tsx
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>
 //
 import { Footer } from "@/components/dashboard/footer";
-import { Navbar } from "@/components/dashboard/navbar";
+import { NavbarWithSuspense as Navbar } from "@/components/dashboard/navbar-wrapper";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 /**

--- a/frontend/app/legal/terms/page.tsx
+++ b/frontend/app/legal/terms/page.tsx
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>
 //
 import { Footer } from "@/components/dashboard/footer";
-import { Navbar } from "@/components/dashboard/navbar";
+import { NavbarWithSuspense as Navbar } from "@/components/dashboard/navbar-wrapper";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 /**

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -18,7 +18,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { Navbar } from "@/components/dashboard/navbar";
+import { NavbarWithSuspense as Navbar } from "@/components/dashboard/navbar-wrapper";
 import { Footer } from "@/components/dashboard/footer";
 
 /**

--- a/frontend/app/manifestation/[id]/page.tsx
+++ b/frontend/app/manifestation/[id]/page.tsx
@@ -18,7 +18,7 @@
 import { useParams } from "next/navigation";
 import Image from "next/image";
 import { BookOpen, Loader2 } from "lucide-react";
-import { Navbar } from "@/components/dashboard/navbar";
+import { NavbarWithSuspense as Navbar } from "@/components/dashboard/navbar-wrapper";
 import { Footer } from "@/components/dashboard/footer";
 import { useManifestation, useProfile, useAddItem } from "@/lib/api/hooks";
 import { getCoverUrl, getCoverTimestamp } from "@/lib/utils";

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -15,7 +15,7 @@
 //
 "use client";
 
-import { Navbar } from "@/components/dashboard/navbar";
+import { NavbarWithSuspense as Navbar } from "@/components/dashboard/navbar-wrapper";
 import { Footer } from "@/components/dashboard/footer";
 import { StatsCards } from "@/components/dashboard/stats-cards";
 import { CurrentContext } from "@/components/dashboard/current-context";

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -20,7 +20,7 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { apiFetch, apiClient } from "@/lib/api/client"; // Use your configured client
-import { Navbar } from "@/components/dashboard/navbar";
+import { NavbarWithSuspense as Navbar } from "@/components/dashboard/navbar-wrapper";
 import { Footer } from "@/components/dashboard/footer";
 import { Avatar } from "@/components/ui/avatar";
 import { useAppConfig } from "@/lib/api/hooks";

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -18,7 +18,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Navbar } from "@/components/dashboard/navbar";
+import { NavbarWithSuspense as Navbar } from "@/components/dashboard/navbar-wrapper";
 import { Footer } from "@/components/dashboard/footer";
 
 /**

--- a/frontend/components/dashboard/navbar-wrapper.tsx
+++ b/frontend/components/dashboard/navbar-wrapper.tsx
@@ -1,0 +1,31 @@
+// Copyright (C) 2026 Sebastian Ryszard Kruk (dev@kruk.me)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>
+//
+"use client";
+
+import { Suspense } from "react";
+import { Navbar } from "./navbar";
+
+function NavbarSkeleton() {
+  return <div className="sticky top-0 z-50 h-16 bg-primary" />;
+}
+
+export function NavbarWithSuspense() {
+  return (
+    <Suspense fallback={<NavbarSkeleton />}>
+      <Navbar />
+    </Suspense>
+  );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11248,6 +11248,7 @@
       "version": "11.0.10",
       "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-11.0.10.tgz",
       "integrity": "sha512-+5FfDXUgYLLqBh1Y/uQhIycpHCbXkI50a+nbfkB1C0xXXUTwkisHDo2QCB1SQJyHCqIuia4FeyReqXuMDKWQTQ==",
+      "license": "ISC",
       "peerDependencies": {
         "react": ">=16.13.1"
       }


### PR DESCRIPTION
## Summary
- Fix `react-image-crop` missing from `node_modules` causing module-not-found build error
- Add `frontend/.dockerignore` to exclude `node_modules`, `.next`, and `.git` from Docker build context
- Wrap `Navbar` component with `Suspense` boundary (`navbar-wrapper.tsx`) to fix `useSearchParams()` build error
- Update all page imports to use `NavbarWithSuspense`

## Root Cause
The release workflow was failing because:
1. `react-image-crop` was in `package.json` but missing from `node_modules` (out of sync with lock file)
2. `Navbar` uses `useSearchParams()` without Suspense wrapper, causing Next.js 16 static generation to fail

## Verification
- `npm run build` now succeeds locally
- `docker build -f frontend/Dockerfile.prod frontend/` completes successfully

## Related
Fixes release workflow failures in GitHub Actions