### PR TITLE
hotfix/0.7.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,8 +46,9 @@ services:
       - ./exports:/usr/src/app/exports
       - ./app/static/covers:/usr/src/app/app/static/covers
       - ./app/static/gallery:/usr/src/app/app/static/gallery
+      - ./scripts:/usr/src/app/scripts
     ports:
-      - "127.0.0.1:5000:5000"
+      - "127.0.0.1:${WEB_PORT:-5000}:5000"
 
   frontend:
     build:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.5] - 2026-06-10
+
+### Fixed
+
+- **Missing `sync_db_permissions.py` on preview instance**: Copied the lightweight `scripts/sync_db_permissions.py` from production to the preview codebase and added `./scripts` volume mount in `docker-compose.yml` so pre-built images pick up the local script. The script syncs permissions and roles from `shared/permissions.yaml` into the DB at container startup without clobbering existing assignments.
+
 ## [0.7.4] - 2026-06-08
 
 ### Fixed
 
-- **Database Permissions Sync on Startup**: Modified the `web` service startup command in `docker-compose.yml` to automatically execute `scripts/init_auth.py` after database migration upgrades. This ensures that new permissions (such as `write:item`) are automatically populated and assigned to user roles when deploying container updates, resolving 403 Forbidden errors when users attempt to add manifestations to their collections.
+- **Database Permissions Sync on Startup**: Modified the `web` service startup command in `docker-compose.yml` to automatically execute `scripts/sync_db_permissions.py` after database migration upgrades. This ensures that new permissions (such as `write:item`) are automatically populated and assigned to user roles when deploying container updates, resolving 403 Forbidden errors when users attempt to add manifestations to their collections.
 - **Production Deployment Exit Status**: Fixed a bash short-circuit bug in `run.sh` that caused the script to exit with code `1` (triggering `make: *** [Makefile:171: start] Error 1` failures) upon successful production deployment. Replaced the `[ "$MODE" != "prod" ] && echo` line with a proper `if` block.
 - **Collection Grid Scope Resolution**: Fixed a regression where the Collection view was still passing `true` for the `includePublic` parameter to `useInfiniteItems`, causing other users' public items to appear in the user's private collection with a "Request Loan" button instead of the status dropdowns.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iqoqo",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iqoqo",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "eslint": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iqoqo",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "The Library of Everything - A distributed, semantic, and federated library system",
   "private": true,
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "iqoqo"
-version = "0.7.4"
+version = "0.7.5"
 description = "Library of Everything - FRBR-compliant personal collection manager"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/sync_db_permissions.py
+++ b/scripts/sync_db_permissions.py
@@ -1,0 +1,123 @@
+# Copyright (C) 2026 Sebastian Ryszard Kruk (dev@kruk.me)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>
+#
+
+"""Dedicated script to sync permissions and default roles without clobbering."""
+
+from pathlib import Path
+
+from dotenv import load_dotenv
+from flask import Flask
+
+# Load environment variables before importing models to ensure schema detection works
+load_dotenv()
+
+import yaml
+
+from app import create_app
+from app.core.permissions import PermissionName
+from app.db.models import Permission, Role, db
+
+
+def run_sync_permissions(app: Flask | None = None) -> None:
+    if app is None:
+        app = create_app()
+
+    with app.app_context():
+        # 1. Sync permissions from shared/permissions.yaml
+        permissions_path = Path(app.root_path).parent / "shared" / "permissions.yaml"
+
+        with open(permissions_path, encoding="utf-8") as f:
+            permissions_data = yaml.safe_load(f)
+
+        permissions_list = permissions_data.get("permissions", [])
+
+        # Validate that all permissions in YAML are also in the Enum
+        enum_values = {p.value for p in PermissionName}
+        for p_data in permissions_list:
+            name = p_data["name"]
+            if name not in enum_values:
+                print(f"WARNING: Permission '{name}' found in YAML but not in PermissionName Enum!")
+
+        for p_data in permissions_list:
+            name = p_data["name"]
+            description = p_data.get("description", "")
+            existing = db.session.execute(db.select(Permission).filter_by(name=name)).scalar_one_or_none()
+            if not existing:
+                db.session.add(Permission(name=name, description=description))
+            else:
+                if existing.description != description:
+                    existing.description = description
+                    print(f"Updated description for permission: {name}")
+        db.session.commit()
+
+        # 2. Sync Roles (Create if missing)
+        admin_role = db.session.execute(db.select(Role).filter_by(name="admin")).scalar_one_or_none()
+        if not admin_role:
+            admin_role = Role(name="admin")
+            db.session.add(admin_role)
+
+        user_role = db.session.execute(db.select(Role).filter_by(name="user")).scalar_one_or_none()
+        if not user_role:
+            user_role = Role(name="user")
+            db.session.add(user_role)
+
+        contributor_role = db.session.execute(db.select(Role).filter_by(name="contributor")).scalar_one_or_none()
+        if not contributor_role:
+            contributor_role = Role(name="contributor")
+            db.session.add(contributor_role)
+
+        db.session.commit()
+
+        # 3. Add default permissions to roles without clobbering existing ones
+        all_perms = db.session.execute(db.select(Permission)).scalars().all()
+
+        # Admin gets all permissions
+        for p in all_perms:
+            if p not in admin_role.permissions:
+                admin_role.permissions.append(p)
+
+        # Contributor gets metadata, llm_generate, delete item, and edit:cover
+        for p in all_perms:
+            is_contrib_perm = (
+                p.name.endswith(":metadata")
+                or p.name == PermissionName.EDIT_COVER.value
+                or p.name.startswith("llm_generate:")
+                or p.name == PermissionName.DELETE_ITEM.value
+            )
+            if is_contrib_perm and p not in contributor_role.permissions:
+                contributor_role.permissions.append(p)
+
+        # Standard User gets permissions to interact with items and basic tasks
+        user_perm_names = {
+            PermissionName.WRITE_ITEM.value,
+            PermissionName.UPDATE_ITEM.value,
+            PermissionName.DELETE_ITEM.value,
+            PermissionName.READ_METADATA.value,
+            PermissionName.UPLOAD_COVER.value,
+            PermissionName.REGENERATE_COVER.value,
+            PermissionName.LLM_GENERATE_METADATA.value,
+            PermissionName.LLM_GENERATE_COVER.value,
+        }
+        for p in all_perms:
+            if p.name in user_perm_names and p not in user_role.permissions:
+                user_role.permissions.append(p)
+
+        db.session.commit()
+        print("Permissions and roles synced successfully.")
+
+
+if __name__ == "__main__":
+    run_sync_permissions()

--- a/tests/test_infra_config.py
+++ b/tests/test_infra_config.py
@@ -32,7 +32,7 @@ class TestRunScripts(unittest.TestCase):
         self.script_path.write_text(self.run_sh.read_text())
         self.script_path.chmod(0o755)
 
-        (self.work_dir / "pyproject.toml").write_text('[project]\nversion = "0.7.4"')
+        (self.work_dir / "pyproject.toml").write_text('[project]\nversion = "0.7.5"')
 
         # Create a mock bin directory to prevent actual execution of Docker/Flask
         self.bin_dir = self.work_dir / "bin"


### PR DESCRIPTION
fix: add missing sync_db_permissions.py for permission sync on startup

Copies scripts/sync_db_permissions.py from production and adds volume mount so pre-built images pick up the local script. Bumps version to 0.7.5.