### PR TITLE
feat(observability): add OTel request_hook middleware and Phase 3 E2E…

### DIFF
--- a/app/core/telemetry.py
+++ b/app/core/telemetry.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2026 Sebastian Ryszard Kruk (dev@kruk.me)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+OpenTelemetry span hooks for the Flask application.
+
+This module provides ``request_hook`` and ``response_hook`` callbacks that are
+registered with ``opentelemetry-instrumentation-flask`` via ``FlaskInstrumentor``.
+
+The primary concern of ``request_hook`` is **credential hygiene**: the Flask
+WSGI environ contains the raw ``HTTP_AUTHORIZATION`` header value which would
+otherwise be captured verbatim in the span attributes and shipped to the
+telemetry backend.  The hook overwrites the attribute with a ``[REDACTED]``
+sentinel before the span is dispatched so that bearer tokens never appear in
+traces, regardless of the OpenObserve / OTel Collector retention policy.
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def request_hook(span: Any, environ: dict) -> None:
+    """Sanitize sensitive WSGI headers before a span is recorded.
+
+    Flask places HTTP request headers in the WSGI ``environ`` dict with an
+    ``HTTP_`` prefix (e.g. ``Authorization`` → ``HTTP_AUTHORIZATION``).  The
+    OpenTelemetry Flask instrumentation captures these values as span
+    attributes.  This hook intercepts that capture and replaces the
+    ``Authorization`` header value with ``[REDACTED]`` to prevent credential
+    leakage into the tracing backend.
+
+    Parameters
+    ----------
+    span:
+        The active ``opentelemetry.trace.Span`` for the current request.
+        The function is a no-op if the span is ``None`` or not recording.
+    environ:
+        The WSGI environ dictionary for the incoming request.
+    """
+    # Guard: span may be None or not yet recording (e.g. sampled out).
+    if span is None:
+        return
+    try:
+        if not span.is_recording():  # type: ignore[union-attr]
+            return
+        if environ.get("HTTP_AUTHORIZATION"):
+            span.set_attribute("http.request.header.authorization", "[REDACTED]")  # type: ignore[union-attr]
+    except Exception:  # pylint: disable=broad-exception-caught
+        # Telemetry hooks must never surface exceptions to application code.
+        logger.debug("request_hook: failed to redact Authorization header", exc_info=True)
+
+
+def response_hook(span: Any, status: str, response_headers: list) -> None:
+    """Post-response span hook — reserved for future response attribute enrichment.
+
+    Parameters
+    ----------
+    span:
+        The active ``opentelemetry.trace.Span`` (may be ``None``).
+    status:
+        The HTTP response status string (e.g. ``\"200 OK\"``).
+    response_headers:
+        List of ``(name, value)`` response header tuples.
+    """
+    # No-op: reserved for future use (e.g. annotating span with response content-type).

--- a/frontend/__tests__/e2e/phase3_devops.spec.ts
+++ b/frontend/__tests__/e2e/phase3_devops.spec.ts
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>
 //
 import { test, expect } from "@playwright/test";
+import packageJson from "../../package.json" assert { type: "json" };
 
 test.describe("Phase 3 DevOps & UI Features", () => {
   test.beforeEach(async ({ page }) => {
@@ -84,5 +85,144 @@ test.describe("Phase 3 DevOps & UI Features", () => {
     // Check if the Maintenance Mode card exists
     await expect(page.getByText("Maintenance Mode")).toBeVisible();
     await expect(page.locator("select")).toBeVisible();
+  });
+});
+
+// ── AdBlocker Resilience ───────────────────────────────────────────────────────
+
+test.describe("Phase 3 — OpenObserve AdBlocker Resilience", () => {
+  /**
+   * This suite verifies that the application renders correctly even when a
+   * browser ad-blocker blocks all OpenObserve RUM and OTel collector endpoints.
+   * Graceful degradation means: no white-screen, navigation is visible,
+   * and the JS error boundary is never triggered.
+   */
+
+  test("App loads successfully even if OpenObserve is blocked by an ad-blocker", async ({ page }) => {
+    // 1. Simulate an ad-blocker aborting all requests to OpenObserve origins
+    await page.route("**/*openobserve*", route => route.abort("blockedbyclient"));
+    await page.route("**/*o2jam*", route => route.abort("blockedbyclient"));
+
+    // 2. Mock profile as unauthenticated so we land on the public hero
+    await page.route("**/api/profile**", route =>
+      route.fulfill({
+        status: 401,
+        json: { success: false, error: "Unauthorized" },
+      })
+    );
+
+    await page.route("**/api/config**", route =>
+      route.fulfill({
+        status: 200,
+        json: { success: true, data: { federation_enabled: false, version: packageJson.version } },
+      })
+    );
+
+    // 3. Verify no console errors that reference a JS crash from RUM init
+    const consoleErrors: string[] = [];
+    page.on("console", msg => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto("/");
+
+    // 4. Core assertions: body and navigation must be visible
+    await expect(page.locator("body")).toBeVisible();
+    await expect(page.getByRole("navigation")).toBeVisible();
+
+    // 5. The page must NOT be a blank white-screen (detect React error boundary)
+    const errorBoundaryText = page.locator("[data-testid='error-boundary-fallback']");
+    await expect(errorBoundaryText).toHaveCount(0);
+
+    // 6. No uncaught exceptions from the RUM SDK init should appear as errors
+    const rumCrashErrors = consoleErrors.filter(
+      e => e.toLowerCase().includes("uncaught") && e.toLowerCase().includes("openobserve")
+    );
+    expect(rumCrashErrors).toHaveLength(0);
+  });
+});
+
+// ── FRBR Virtual Item QR Code Boundary ────────────────────────────────────────
+
+test.describe("Phase 3 — FRBR Wishlist QR Code Boundary", () => {
+  /**
+   * Enforces the FRBR ontology rule:
+   *   Virtual items (id < 0) are UserWorkIntent adapters with no physical copy.
+   *   They must NEVER expose a QR Code generation button.
+   *
+   * This test intercepts the item API response and forces a wishlist state
+   * to validate that the frontend component correctly hides the QR Code button.
+   */
+
+  test.beforeEach(async ({ page }) => {
+    // Authenticate as a normal item owner
+    await page.route("**/api/profile**", route =>
+      route.fulfill({
+        status: 200,
+        json: {
+          success: true,
+          data: {
+            id: "owner-user-id",
+            email: "owner@iqoqo.local",
+            permissions: ["update:item", "write:metadata", "upload:cover"],
+            roles: [],
+          },
+        },
+      })
+    );
+
+    await page.route("**/api/config**", route =>
+      route.fulfill({
+        status: 200,
+        json: {
+          success: true,
+          data: { federation_enabled: false, version: packageJson.version },
+        },
+      })
+    );
+  });
+
+  test("Wishlist items do not display a QR Code button", async ({ page }) => {
+    // 1. Mock GET /api/items/-1 to return a virtual wishlist item payload
+    await page.route("**/api/items/-1**", async route => {
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            id: -1,
+            title: "Virtual Wishlist Book",
+            status: "want_to_read",
+            collection_status: "wish_list",
+            manifestation_id: null,
+            is_owner: true,
+            owner_id: "owner-user-id",
+            meta: { format: "book" },
+          },
+        }),
+      });
+    });
+
+    // 2. Virtual item logs return an empty array (expected FRBR contract)
+    await page.route("**/api/items/-1/logs**", route =>
+      route.fulfill({
+        status: 200,
+        json: { success: true, data: [] },
+      })
+    );
+
+    await page.goto("/item/-1");
+    await page.waitForLoadState("networkidle");
+
+    // 3. Assert QR Code button is ABSENT for the virtual wishlist item
+    await expect(page.getByTestId("qrcode-btn")).toHaveCount(0);
+    await expect(page.locator("button", { hasText: "Print QR Code" })).toHaveCount(0);
   });
 });

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -1,0 +1,119 @@
+# Copyright (C) 2026 Sebastian Ryszard Kruk (dev@kruk.me)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for the OpenTelemetry middleware hooks in app.core.telemetry.
+
+These tests assert that:
+- ``request_hook`` redacts the ``Authorization`` header before a span is dispatched.
+- ``request_hook`` leaves spans unmodified when no Authorization header is present.
+- ``request_hook`` is safe against a None span or a non-recording span.
+- ``response_hook`` is a no-op (reserved for future use).
+"""
+
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from app.core.telemetry import request_hook, response_hook
+
+
+class TestRequestHookRedactsAuthHeader:
+    """Ensure ``request_hook`` intercepts Authorization headers and marks them [REDACTED]."""
+
+    def test_redacts_bearer_token_when_present(self) -> None:
+        """Assert that a Bearer token in HTTP_AUTHORIZATION is overwritten with [REDACTED]."""
+        span = MagicMock()
+        span.is_recording.return_value = True
+
+        environ = {
+            "HTTP_AUTHORIZATION": "Bearer sensitive-token-abc123",
+            "PATH_INFO": "/api/secure-endpoint",
+        }
+
+        request_hook(span, environ)
+
+        span.set_attribute.assert_called_once_with("http.request.header.authorization", "[REDACTED]")
+
+    def test_does_not_set_attribute_when_authorization_absent(self) -> None:
+        """Assert that requests without an Authorization header pass through unmodified."""
+        span = MagicMock()
+        span.is_recording.return_value = True
+
+        environ = {
+            "PATH_INFO": "/api/public-endpoint",
+            "REQUEST_METHOD": "GET",
+        }
+
+        request_hook(span, environ)
+
+        span.set_attribute.assert_not_called()
+
+    def test_no_op_when_span_is_none(self) -> None:
+        """Assert that a None span does not raise and exits cleanly."""
+        environ = {"HTTP_AUTHORIZATION": "Bearer token"}
+
+        # Must not raise
+        request_hook(None, environ)
+
+    def test_no_op_when_span_is_not_recording(self) -> None:
+        """Assert that a non-recording span (e.g. sampled-out) is skipped silently."""
+        span = MagicMock()
+        span.is_recording.return_value = False
+
+        environ = {"HTTP_AUTHORIZATION": "Bearer token"}
+
+        request_hook(span, environ)
+
+        span.set_attribute.assert_not_called()
+
+    def test_redacts_basic_auth_token(self) -> None:
+        """Assert that HTTP Basic Auth (non-Bearer) is also redacted."""
+        span = MagicMock()
+        span.is_recording.return_value = True
+
+        environ = {
+            "HTTP_AUTHORIZATION": "Basic dXNlcjpwYXNzd29yZA==",
+            "PATH_INFO": "/api/items/",
+        }
+
+        request_hook(span, environ)
+
+        span.set_attribute.assert_called_once_with("http.request.header.authorization", "[REDACTED]")
+
+    def test_tolerates_set_attribute_raising_exception(self) -> None:
+        """Assert that internal span errors never propagate to application code."""
+        span = MagicMock()
+        span.is_recording.return_value = True
+        span.set_attribute.side_effect = RuntimeError("span is closed")
+
+        environ = {"HTTP_AUTHORIZATION": "Bearer token"}
+
+        # Must not raise
+        request_hook(span, environ)
+
+
+class TestResponseHook:
+    """Verify that response_hook is currently a safe no-op."""
+
+    def test_response_hook_is_noop(self) -> None:
+        """Assert that response_hook returns None and performs no side effects."""
+        span = MagicMock()
+        response_hook(span, "200 OK", [("Content-Type", "application/json")])
+        span.set_attribute.assert_not_called()
+
+    def test_response_hook_accepts_none_span(self) -> None:
+        """Assert that response_hook tolerates a None span without raising."""
+        response_hook(None, "500 Internal Server Error", [])  # must not raise


### PR DESCRIPTION
… tests

- Add app/core/telemetry.py: request_hook() redacts HTTP_AUTHORIZATION from WSGI environ before OpenTelemetry Flask span is dispatched.  Prevents bearer tokens from leaking into OpenObserve traces regardless of retention policy. response_hook() is a documented no-op reserved for future enrichment.

- Add tests/core/test_telemetry.py: 8 unit tests covering the full contract of request_hook (Bearer redaction, Basic-Auth redaction, missing header no-op, None-span guard, non-recording-span guard, internal exception swallowing) and response_hook (no-op, None-span tolerance).  pylint 10/10, mypy clean.

- Extend frontend/__tests__/e2e/phase3_devops.spec.ts with two new test.describe blocks from the Phase 3 implementation plan:
    - 'Phase 3 — OpenObserve AdBlocker Resilience': aborts all openobserve routes and asserts the page body and navigation remain visible with no React crash.
    - 'Phase 3 — FRBR Wishlist QR Code Boundary': intercepts /api/items/-1 to force a virtual wishlist state and asserts the qrcode-btn is absent (FRBR ontology rule: virtual items cannot have physical QR labels).