### PR TITLE
feat: collection management & wishlist UX (v0.7.9 phase 3)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Allegro Auth Handshake CLI**: Deployed `make allegro-auth` target wrapping the interactive `scripts/allegro_auth.py` script for local and Docker setups.
 - **Allegro Status Checks**: Integrated Allegro API activation checks into `make status` / `scripts/iqoqo-status.sh` to report configured, active (token present), or pending handshake states.
 - **Allegro Cover Refetch Fallback**: Integrated Allegro API cover retrieval into the background cover refetch pipeline (`fetch_external_api_cover` in `app/utils/covers.py`), adding support for both ISBN and non-ISBN identifiers.
+- **Collection Management UX (Phase 3)**: Added full Create, Update, and Remove collection operations to `ManageCollectionsModal` with inline form, toast notifications, and mutation invalidation. Refactored `ItemCard` to include instant wishlist subtraction via hover-revealed `HeartOff` button, calling `DELETE /items/:id` directly. Implemented dynamic cross-filtering visual treatment in `SidebarFilters` - facets with zero result count are now disabled and visually muted unless currently selected.
+- **E2E Coverage (Phase 3)**: Created `manage_collections.spec.ts` Playwright test for full CRUD modal workflow. Added instant wishlist subtraction E2E test to `wishlist_workflow.spec.ts` and dynamic facet cross-filtering E2E test to `faceted_catalog_sync.spec.ts`.
+- **Unit Test Expansion**: Added unit tests for wishlist removal button rendering and callback behavior in `item-card.test.tsx`, collection creation via form in `manage-collections-modal.test.tsx`, and cross-filtering disabled/opacity-50 treatment in `sidebar-filters.test.tsx`.
 
 ### Fixed
 

--- a/frontend/__tests__/components/collection/item-card.test.tsx
+++ b/frontend/__tests__/components/collection/item-card.test.tsx
@@ -19,10 +19,12 @@
  * ItemCard is a pure presentational component – no hooks, just props.
  * next/link is mocked globally via vitest.setup.ts.
  */
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Item, CatalogEntry } from "@/types/frbr";
 import { ItemCard } from "@/components/collection/item-card";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { apiClient } from "@/lib/api/client";
 
 vi.mock("next/navigation", () => ({
   usePathname: vi.fn().mockReturnValue("/"),
@@ -30,6 +32,26 @@ vi.mock("next/navigation", () => ({
     push: vi.fn(),
   }),
 }));
+
+vi.mock("@/lib/api/client", () => ({
+  apiClient: {
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+const renderWithQuery = (ui: React.ReactElement) =>
+  render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
 
 /**
  * Make a mock Item.
@@ -70,83 +92,87 @@ function makeCatalogEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
 }
 
 describe("ItemCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("displays the item title", () => {
-    render(<ItemCard item={makeItem()} />);
+    renderWithQuery(<ItemCard item={makeItem()} />);
     expect(screen.getAllByText("Dune").length).toBeGreaterThan(0);
   });
 
   it("displays the first author name", () => {
-    render(<ItemCard item={makeItem()} />);
+    renderWithQuery(<ItemCard item={makeItem()} />);
     expect(screen.getAllByText("Frank Herbert").length).toBeGreaterThan(0);
   });
 
   it("falls back to 'Untitled' when title is missing", () => {
-    render(<ItemCard item={makeItem({ title: undefined })} />);
+    renderWithQuery(<ItemCard item={makeItem({ title: undefined })} />);
     expect(screen.getAllByText("Untitled").length).toBeGreaterThan(0);
   });
 
   it("falls back to 'Unknown author' when authors is missing", () => {
-    render(<ItemCard item={makeItem({ authors: undefined })} />);
+    renderWithQuery(<ItemCard item={makeItem({ authors: undefined })} />);
     expect(screen.getAllByText("Unknown author").length).toBeGreaterThan(0);
   });
 
   it("links to the item detail page", () => {
-    render(<ItemCard item={makeItem({ id: 42 })} />);
+    renderWithQuery(<ItemCard item={makeItem({ id: 42 })} />);
     expect(screen.getByRole("link")).toHaveAttribute("href", "/item/42");
   });
 
   it("shows a quantity badge when _quantity > 1", () => {
     const item = makeItem();
     (item as Item & { _quantity?: number })._quantity = 3;
-    render(<ItemCard item={item} />);
+    renderWithQuery(<ItemCard item={item} />);
     expect(screen.getByText("x3")).toBeInTheDocument();
   });
 
   it("does not show a quantity badge when _quantity is 1 or undefined", () => {
     const item = makeItem();
-    render(<ItemCard item={item} />);
+    renderWithQuery(<ItemCard item={item} />);
     expect(screen.queryByText(/^x\d+$/)).not.toBeInTheDocument();
   });
 
   it("renders a cover placeholder when coverUrl is absent", () => {
-    render(<ItemCard item={makeItem({ meta: {}, manifestation_meta: {} })} />);
+    renderWithQuery(<ItemCard item={makeItem({ meta: {}, manifestation_meta: {} })} />);
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
   });
 
   it("shows a status dot with the correct title for 'available'", () => {
-    render(<ItemCard item={makeItem({ collection_status: "available", status: "want_to_read" })} />);
+    renderWithQuery(<ItemCard item={makeItem({ collection_status: "available", status: "want_to_read" })} />);
     expect(screen.getByTitle("Want to Read")).toBeInTheDocument();
   });
 
   it("shows a status dot with the correct title for 'lent'", () => {
-    render(<ItemCard item={makeItem({ collection_status: "lent" })} />);
+    renderWithQuery(<ItemCard item={makeItem({ collection_status: "lent" })} />);
     expect(screen.getByTitle("Lent Out")).toBeInTheDocument();
   });
 
   it("shows a status dot with the correct title for 'wish_list'", () => {
-    render(<ItemCard item={makeItem({ collection_status: "wish_list" })} />);
+    renderWithQuery(<ItemCard item={makeItem({ collection_status: "wish_list" })} />);
     expect(screen.getByTitle("On Wish List")).toBeInTheDocument();
   });
 
   it("shows a status dot with the correct title for 'lost'", () => {
-    render(<ItemCard item={makeItem({ collection_status: "lost" })} />);
+    renderWithQuery(<ItemCard item={makeItem({ collection_status: "lost" })} />);
     expect(screen.getByTitle("Lost")).toBeInTheDocument();
   });
 
   it("renders a cover image when coverUrl is provided in meta", () => {
-    render(<ItemCard item={makeItem({ meta: { cover_url: "https://example.com/cover.jpg" } })} />);
+    renderWithQuery(<ItemCard item={makeItem({ meta: { cover_url: "https://example.com/cover.jpg" } })} />);
     const img = screen.getByRole("img");
     expect(img).toHaveAttribute("src", "https://example.com/cover.jpg");
     expect(img).toHaveAttribute("alt", "Cover of Dune");
   });
 
   it("links to the manifestation detail page when isManifestationView is true", () => {
-    render(<ItemCard item={makeCatalogEntry({ id: 99 })} isManifestationView={true} />);
+    renderWithQuery(<ItemCard item={makeCatalogEntry({ id: 99 })} isManifestationView={true} />);
     expect(screen.getByRole("link")).toHaveAttribute("href", "/manifestation/99");
   });
 
   it("hides the user item status dot when isManifestationView is true", () => {
-    render(<ItemCard item={makeCatalogEntry()} isManifestationView={true} />);
+    renderWithQuery(<ItemCard item={makeCatalogEntry()} isManifestationView={true} />);
     expect(screen.queryByTitle("On Shelf")).not.toBeInTheDocument();
   });
 
@@ -163,7 +189,7 @@ describe("ItemCard", () => {
   });
 
   it("does not show 'In Collection' badge when user_owns is false", () => {
-    render(<ItemCard item={makeCatalogEntry({ user_owns: false })} isManifestationView={true} />);
+    renderWithQuery(<ItemCard item={makeCatalogEntry({ user_owns: false })} isManifestationView={true} />);
     expect(screen.queryByText("In Collection")).not.toBeInTheDocument();
     expect(screen.queryByText("In Collection →")).not.toBeInTheDocument();
   });
@@ -181,12 +207,12 @@ describe("ItemCard", () => {
   });
 
   it("renders a cover placeholder in horizontal variant when coverUrl is absent", () => {
-    render(<ItemCard item={makeItem({ meta: {} })} variant="horizontal" />);
+    renderWithQuery(<ItemCard item={makeItem({ meta: {} })} variant="horizontal" />);
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
   });
 
   it("does not show 'In Collection' badge when owner_id is 'Unavailable'", () => {
-    render(<ItemCard item={makeItem({ owner_id: "Unavailable" })} />);
+    renderWithQuery(<ItemCard item={makeItem({ owner_id: "Unavailable" })} />);
     expect(screen.queryByText("In Collection")).not.toBeInTheDocument();
   });
 
@@ -195,10 +221,60 @@ describe("ItemCard", () => {
     // The ItemCard must never crash when this field is missing.
     const virtualItem = makeItem({ id: -5, manifestation_id: undefined, title: "Virtual Book" });
     // Should render without throwing
-    render(<ItemCard item={virtualItem} />);
+    renderWithQuery(<ItemCard item={virtualItem} />);
     // Title still rendered
     expect(screen.getAllByText("Virtual Book").length).toBeGreaterThan(0);
     // Link still points to item page (not manifestation page)
     expect(screen.getByRole("link")).toHaveAttribute("href", "/item/-5");
+  });
+
+  it("renders wishlist drop button when collection_status is wish_list", () => {
+    renderWithQuery(<ItemCard item={makeItem({ id: -10, collection_status: "wish_list" })} />);
+    expect(screen.getByLabelText("Remove from wishlist")).toBeInTheDocument();
+  });
+
+  it("does not render wishlist drop button when collection_status is not wish_list", () => {
+    renderWithQuery(<ItemCard item={makeItem({ collection_status: "available" })} />);
+    expect(screen.queryByLabelText("Remove from wishlist")).not.toBeInTheDocument();
+  });
+
+  it("calls onWishlistRemove callback and API when wishlist button is clicked", async () => {
+    const onWishlistRemove = vi.fn();
+    vi.mocked(apiClient.delete).mockResolvedValueOnce({ data: { success: true } });
+
+    renderWithQuery(
+      <ItemCard
+        item={makeItem({ id: -10, collection_status: "wish_list", title: "Dune" })}
+        onWishlistRemove={onWishlistRemove}
+      />
+    );
+
+    const removeBtn = screen.getByLabelText("Remove from wishlist");
+    fireEvent.click(removeBtn);
+
+    await waitFor(() => {
+      expect(apiClient.delete).toHaveBeenCalledWith("/items/-10");
+      expect(onWishlistRemove).toHaveBeenCalledWith(-10);
+    });
+  });
+
+  it("shows error toast when wishlist removal fails", async () => {
+    const { toast } = await import("sonner");
+    vi.mocked(apiClient.delete).mockRejectedValueOnce(new Error("Network error"));
+
+    renderWithQuery(<ItemCard item={makeItem({ id: -10, collection_status: "wish_list" })} />);
+
+    fireEvent.click(screen.getByLabelText("Remove from wishlist"));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Network error");
+    });
+  });
+
+  it("shows HeartOff in horizontal variant for wishlist items", () => {
+    renderWithQuery(
+      <ItemCard item={makeItem({ id: -5, collection_status: "wish_list", title: "Wish Book" })} variant="horizontal" />
+    );
+    expect(screen.getByLabelText("Remove from wishlist")).toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/components/collection/manage-collections-modal.test.tsx
+++ b/frontend/__tests__/components/collection/manage-collections-modal.test.tsx
@@ -27,6 +27,7 @@ vi.mock("@/lib/api/client", () => ({
     get: vi.fn(),
     put: vi.fn(),
     delete: vi.fn(),
+    post: vi.fn(),
   },
 }));
 
@@ -100,6 +101,49 @@ describe("ManageCollectionsModal", () => {
     await waitFor(() => {
       expect(global.confirm).toHaveBeenCalled();
       expect(apiClient.delete).toHaveBeenCalledWith("/collections/1");
+    });
+  });
+
+  it("creates a new collection via the form", async () => {
+    renderComponent();
+
+    vi.mocked(apiClient.post).mockResolvedValueOnce({
+      data: { success: true, collection: { id: 3, name: "History" } },
+    });
+
+    const input = screen.getByPlaceholderText("New collection name");
+    fireEvent.change(input, { target: { value: "History" } });
+
+    const addButton = screen.getByText("Add");
+    fireEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith("/collections", {
+        name: "History",
+      });
+    });
+  });
+
+  it("does not create a collection with empty name", () => {
+    renderComponent();
+
+    const addButton = screen.getByText("Add");
+    expect(addButton).toBeDisabled();
+  });
+
+  it("clears input after successful creation", async () => {
+    renderComponent();
+
+    vi.mocked(apiClient.post).mockResolvedValueOnce({
+      data: { success: true, collection: { id: 4, name: "Poetry" } },
+    });
+
+    const input = screen.getByPlaceholderText("New collection name");
+    fireEvent.change(input, { target: { value: "Poetry" } });
+    fireEvent.click(screen.getByText("Add"));
+
+    await waitFor(() => {
+      expect(input).toHaveValue("");
     });
   });
 });

--- a/frontend/__tests__/components/collection/sidebar-filters.test.tsx
+++ b/frontend/__tests__/components/collection/sidebar-filters.test.tsx
@@ -110,3 +110,61 @@ describe("SidebarFilters with Searchable Facets", () => {
     expect(useTaxonomies).toHaveBeenLastCalledWith({ scope: "user", filters: {} });
   });
 });
+
+describe("SidebarFilters Cross-Filtering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useTaxonomies).mockReturnValue({
+      data: {
+        genres: [],
+        tags: [],
+        publishers: [],
+        collections: [],
+      },
+    } as unknown as ReturnType<typeof useTaxonomies>);
+  });
+
+  it("applies opacity-50 to status options with zero count when not selected", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SidebarFilters
+          activeFilters={[]}
+          onToggleFilter={vi.fn()}
+          statusCounts={{ wish_list: 0, available: 5, ordered: 0 }}
+        />
+      </QueryClientProvider>
+    );
+
+    const wishListLabel = screen.getByText("On Wish List").closest("label");
+    const availableLabel = screen.getByText("On Shelf").closest("label");
+
+    expect(wishListLabel?.className).toContain("opacity-50");
+    expect(availableLabel?.className).not.toContain("opacity-50");
+  });
+
+  it("keeps zero-count status enabled if currently selected", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SidebarFilters
+          activeFilters={[{ type: "status", value: "wish_list" }]}
+          onToggleFilter={vi.fn()}
+          statusCounts={{ wish_list: 0, available: 5 }}
+        />
+      </QueryClientProvider>
+    );
+
+    const wishListCheckbox = screen.getByRole("checkbox", { name: "On Wish List 0" });
+    expect(wishListCheckbox).not.toBeDisabled();
+  });
+
+  it("disables unchecked zero-count status inputs", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SidebarFilters activeFilters={[]} onToggleFilter={vi.fn()} statusCounts={{ wish_list: 0, ordered: 0 }} />
+      </QueryClientProvider>
+    );
+
+    const wishListCheckbox = screen.getByRole("checkbox", { name: "On Wish List 0" });
+    expect(wishListCheckbox).toBeDisabled();
+  });
+});

--- a/frontend/__tests__/e2e/faceted_catalog_sync.spec.ts
+++ b/frontend/__tests__/e2e/faceted_catalog_sync.spec.ts
@@ -269,3 +269,104 @@ test.describe("Faceted Catalog Synchronization and Inventory Isolation", () => {
     await expect(page.getByText("Global Fiction Novel")).not.toBeVisible();
   });
 });
+
+test.describe("Dynamic Facet Cross-Filtering", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem("iqoqo-cookie-consent", "true");
+    });
+
+    await page.route("**/api/profile**", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            id: "e2e-admin-id",
+            email: "e2e-admin@iqoqo.local",
+            permissions: ["upload:cover", "write:metadata", "update:item"],
+          },
+        }),
+      });
+    });
+
+    await page.route("**/api/config**", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: { federation_enabled: false, version: "1.0.0" },
+        }),
+      });
+    });
+
+    await page.route("**/api/taxonomies**", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: { genres: [], publishers: [], tags: [], collections: [] },
+        }),
+      });
+    });
+
+    await page.route("**/api/manifestations**", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: [], meta: { total: 0 } }),
+      });
+    });
+
+    await page.route("**/api/items**", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: [],
+          meta: { page: 1, pages: 1, total: 0, limit: 20 },
+        }),
+      });
+    });
+  });
+
+  test("mutes status options with zero count when not selected", async ({ page }) => {
+    // Mock stats with some statuses having zero count
+    await page.route("**/api/stats**", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            works: 10,
+            items: 5,
+            wish_list: 0,
+            available: 5,
+            ordered: 0,
+            lent: 0,
+            lost: 0,
+          },
+        }),
+      });
+    });
+
+    await page.goto("/collection");
+    await page.waitForLoadState("networkidle");
+
+    // "On Shelf" (available) has count 5 - should be fully visible (no opacity-50)
+    const onShelfLabel = page.locator("label").filter({ hasText: "On Shelf" });
+    await expect(onShelfLabel).toBeVisible();
+    // It should NOT have the opacity-50 class
+    await expect(onShelfLabel).not.toHaveClass(/opacity-50/);
+
+    // "On Wish List" has count 0 - should be muted (opacity-50) since not selected
+    const onWishListLabel = page.locator("label").filter({ hasText: "On Wish List" });
+    await expect(onWishListLabel).toBeVisible();
+    await expect(onWishListLabel).toHaveClass(/opacity-50/);
+  });
+});

--- a/frontend/__tests__/e2e/faceted_catalog_sync.spec.ts
+++ b/frontend/__tests__/e2e/faceted_catalog_sync.spec.ts
@@ -336,6 +336,7 @@ test.describe("Dynamic Facet Cross-Filtering", () => {
 
   test("mutes status options with zero count when not selected", async ({ page }) => {
     // Mock stats with some statuses having zero count
+    // NOTE: the frontend extracts status counts from keys prefixed with "items_"
     await page.route("**/api/stats**", async route => {
       await route.fulfill({
         status: 200,
@@ -345,11 +346,11 @@ test.describe("Dynamic Facet Cross-Filtering", () => {
           data: {
             works: 10,
             items: 5,
-            wish_list: 0,
-            available: 5,
-            ordered: 0,
-            lent: 0,
-            lost: 0,
+            items_wish_list: 0,
+            items_available: 5,
+            items_ordered: 0,
+            items_lent: 0,
+            items_lost: 0,
           },
         }),
       });
@@ -358,14 +359,14 @@ test.describe("Dynamic Facet Cross-Filtering", () => {
     await page.goto("/collection");
     await page.waitForLoadState("networkidle");
 
-    // "On Shelf" (available) has count 5 - should be fully visible (no opacity-50)
-    const onShelfLabel = page.locator("label").filter({ hasText: "On Shelf" });
+    // "On Shelf" (available) has count 5 — should be fully visible (no opacity-50)
+    // Use .first() to avoid strict mode violation from the mobile filter drawer duplicate
+    const onShelfLabel = page.locator("label").filter({ hasText: "On Shelf" }).first();
     await expect(onShelfLabel).toBeVisible();
-    // It should NOT have the opacity-50 class
     await expect(onShelfLabel).not.toHaveClass(/opacity-50/);
 
-    // "On Wish List" has count 0 - should be muted (opacity-50) since not selected
-    const onWishListLabel = page.locator("label").filter({ hasText: "On Wish List" });
+    // "On Wish List" has count 0 — should be muted (opacity-50) since not selected
+    const onWishListLabel = page.locator("label").filter({ hasText: "On Wish List" }).first();
     await expect(onWishListLabel).toBeVisible();
     await expect(onWishListLabel).toHaveClass(/opacity-50/);
   });

--- a/frontend/__tests__/e2e/manage_collections.spec.ts
+++ b/frontend/__tests__/e2e/manage_collections.spec.ts
@@ -129,32 +129,36 @@ test.describe("Manage Collections Modal Workflow", () => {
     // Open Modal via "Manage Collections" menuitem in the user dropdown
     await page.getByLabel("User menu").click();
     await page.getByRole("menuitem", { name: "Manage Collections" }).click();
-    await expect(page.getByRole("heading", { name: "Manage Collections" })).toBeVisible();
+    const heading = page.getByRole("heading", { name: "Manage Collections" });
+    await expect(heading).toBeVisible();
+
+    // Scope to the modal dialog to avoid matching sidebar filter elements
+    const modal = page.locator(".fixed.inset-0.z-50").filter({ has: heading });
 
     // Verify existing collections are listed
-    await expect(page.getByText("Fantasy")).toBeVisible();
-    await expect(page.getByText("Sci-Fi")).toBeVisible();
+    await expect(modal.getByText("Fantasy")).toBeVisible();
+    await expect(modal.getByText("Sci-Fi")).toBeVisible();
 
     // Create a new collection
-    await page.getByPlaceholder("New collection name").fill("Cyberpunk");
-    await page.getByRole("button", { name: "Add" }).click();
+    await modal.getByPlaceholder("New collection name").fill("Cyberpunk");
+    await modal.getByRole("button", { name: "Add" }).click();
 
     // After creation, the input should be cleared and "Collection created" toast shown
-    await expect(page.getByPlaceholder("New collection name")).toHaveValue("");
+    await expect(modal.getByPlaceholder("New collection name")).toHaveValue("");
     await expect(page.getByText("Collection created")).toBeVisible();
 
     // Update a collection name
-    const fantasyRow = page.locator(".flex.items-center.justify-between").filter({ hasText: "Fantasy" });
+    const fantasyRow = modal.locator(".flex.items-center.justify-between").filter({ hasText: "Fantasy" });
     await fantasyRow.getByTitle("Edit Name").click();
-    await page.locator('input[value="Fantasy"]').fill("High Fantasy");
-    await page.getByText("Save").click();
+    await modal.locator('input[value="Fantasy"]').fill("High Fantasy");
+    await modal.getByText("Save").click();
 
     // Verify the rename is reflected
-    await expect(page.getByText("High Fantasy")).toBeVisible();
+    await expect(modal.getByText("High Fantasy")).toBeVisible();
 
     // Delete a collection
-    page.on("dialog", dialog => dialog.accept());
-    const sciFiRow = page.locator(".flex.items-center.justify-between").filter({ hasText: "Sci-Fi" });
+    page.on("dialog", d => d.accept());
+    const sciFiRow = modal.locator(".flex.items-center.justify-between").filter({ hasText: "Sci-Fi" });
     await sciFiRow.getByTitle("Delete Collection").click();
 
     await expect(page.getByText("Collection removed")).toBeVisible();

--- a/frontend/__tests__/e2e/manage_collections.spec.ts
+++ b/frontend/__tests__/e2e/manage_collections.spec.ts
@@ -126,8 +126,9 @@ test.describe("Manage Collections Modal Workflow", () => {
   });
 
   test("allows full CRUD operations on collections", async ({ page }) => {
-    // Open Modal via "Manage Collections" button
-    await page.getByRole("button", { name: "Manage Collections" }).click();
+    // Open Modal via "Manage Collections" menuitem in the user dropdown
+    await page.getByLabel("User menu").click();
+    await page.getByRole("menuitem", { name: "Manage Collections" }).click();
     await expect(page.getByText("Manage Collections")).toBeVisible();
 
     // Verify existing collections are listed

--- a/frontend/__tests__/e2e/manage_collections.spec.ts
+++ b/frontend/__tests__/e2e/manage_collections.spec.ts
@@ -129,7 +129,7 @@ test.describe("Manage Collections Modal Workflow", () => {
     // Open Modal via "Manage Collections" menuitem in the user dropdown
     await page.getByLabel("User menu").click();
     await page.getByRole("menuitem", { name: "Manage Collections" }).click();
-    await expect(page.getByText("Manage Collections")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Manage Collections" })).toBeVisible();
 
     // Verify existing collections are listed
     await expect(page.getByText("Fantasy")).toBeVisible();

--- a/frontend/__tests__/e2e/manage_collections.spec.ts
+++ b/frontend/__tests__/e2e/manage_collections.spec.ts
@@ -1,0 +1,161 @@
+// Copyright (C) 2026 Sebastian Ryszard Kruk (dev@kruk.me)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>
+//
+
+import { test, expect } from "@playwright/test";
+
+test.describe("Manage Collections Modal Workflow", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/profile**", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            id: "e2e-user-id",
+            email: "e2e@iqoqo.local",
+            permissions: ["write:item"],
+          },
+        }),
+      });
+    });
+
+    await page.route("**/api/config**", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: { federation_enabled: false, version: "1.0.0" },
+        }),
+      });
+    });
+
+    // Mock existing collections
+    await page.route("**/api/collections**", async route => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            collections: [
+              { id: 1, name: "Fantasy", parent_id: null },
+              { id: 2, name: "Sci-Fi", parent_id: null },
+            ],
+          }),
+        });
+      } else if (route.request().method() === "POST") {
+        const body = route.request().postDataJSON();
+        await route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            collection: { id: 3, name: body.name, parent_id: null },
+          }),
+        });
+      } else if (route.request().method() === "PUT") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ success: true }),
+        });
+      } else if (route.request().method() === "DELETE") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ success: true }),
+        });
+      } else {
+        await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+      }
+    });
+
+    // Mock taxonomies
+    await page.route("**/api/taxonomies**", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: { genres: [], tags: [], publishers: [], collections: ["Fantasy", "Sci-Fi"] },
+        }),
+      });
+    });
+
+    // Mock items
+    await page.route("**/api/items**", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: [],
+          meta: { page: 1, pages: 1, total: 0, limit: 20 },
+        }),
+      });
+    });
+
+    await page.route("**/api/stats**", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: { works: 0, expressions: 0, manifestations: 0, items: 0 },
+        }),
+      });
+    });
+
+    await page.goto("/collection");
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("allows full CRUD operations on collections", async ({ page }) => {
+    // Open Modal via "Manage Collections" button
+    await page.getByRole("button", { name: "Manage Collections" }).click();
+    await expect(page.getByText("Manage Collections")).toBeVisible();
+
+    // Verify existing collections are listed
+    await expect(page.getByText("Fantasy")).toBeVisible();
+    await expect(page.getByText("Sci-Fi")).toBeVisible();
+
+    // Create a new collection
+    await page.getByPlaceholder("New collection name").fill("Cyberpunk");
+    await page.getByRole("button", { name: "Add" }).click();
+
+    // After creation, the input should be cleared and "Collection created" toast shown
+    await expect(page.getByPlaceholder("New collection name")).toHaveValue("");
+    await expect(page.getByText("Collection created")).toBeVisible();
+
+    // Update a collection name
+    const fantasyRow = page.locator(".flex.items-center.justify-between").filter({ hasText: "Fantasy" });
+    await fantasyRow.getByTitle("Edit Name").click();
+    await page.locator('input[value="Fantasy"]').fill("High Fantasy");
+    await page.getByText("Save").click();
+
+    // Verify the rename is reflected
+    await expect(page.getByText("High Fantasy")).toBeVisible();
+
+    // Delete a collection
+    page.on("dialog", dialog => dialog.accept());
+    const sciFiRow = page.locator(".flex.items-center.justify-between").filter({ hasText: "Sci-Fi" });
+    await sciFiRow.getByTitle("Delete Collection").click();
+
+    await expect(page.getByText("Collection removed")).toBeVisible();
+  });
+});

--- a/frontend/__tests__/e2e/manage_collections.spec.ts
+++ b/frontend/__tests__/e2e/manage_collections.spec.ts
@@ -44,44 +44,54 @@ test.describe("Manage Collections Modal Workflow", () => {
       });
     });
 
-    // Mock existing collections
+    // Mock existing collections — stateful to reflect CRUD mutations
+    const mockCollections = [
+      { id: 1, name: "Fantasy", parent_id: null },
+      { id: 2, name: "Sci-Fi", parent_id: null },
+    ];
+    let nextId = 3;
+
     await page.route("**/api/collections**", async route => {
+      const url = new URL(route.request().url());
+      const idMatch = url.pathname.match(/\/collections\/(\d+)$/);
+      const colId = idMatch ? parseInt(idMatch[1]) : null;
+
       if (route.request().method() === "GET") {
         await route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify({
-            success: true,
-            collections: [
-              { id: 1, name: "Fantasy", parent_id: null },
-              { id: 2, name: "Sci-Fi", parent_id: null },
-            ],
-          }),
+          body: JSON.stringify({ success: true, collections: mockCollections }),
         });
       } else if (route.request().method() === "POST") {
         const body = route.request().postDataJSON();
+        const newCol = { id: nextId++, name: body.name, parent_id: null };
+        mockCollections.push(newCol);
         await route.fulfill({
           status: 201,
           contentType: "application/json",
-          body: JSON.stringify({
-            success: true,
-            collection: { id: 3, name: body.name, parent_id: null },
-          }),
+          body: JSON.stringify({ success: true, collection: newCol }),
         });
-      } else if (route.request().method() === "PUT") {
+      } else if (route.request().method() === "PUT" && colId) {
+        const body = route.request().postDataJSON();
+        const idx = mockCollections.findIndex(c => c.id === colId);
+        if (idx >= 0) mockCollections[idx] = { ...mockCollections[idx], ...body };
         await route.fulfill({
           status: 200,
           contentType: "application/json",
           body: JSON.stringify({ success: true }),
         });
-      } else if (route.request().method() === "DELETE") {
+      } else if (route.request().method() === "DELETE" && colId) {
+        const idx = mockCollections.findIndex(c => c.id === colId);
+        if (idx >= 0) mockCollections.splice(idx, 1);
         await route.fulfill({
           status: 200,
           contentType: "application/json",
           body: JSON.stringify({ success: true }),
         });
-      } else {
+      } else if (route.request().method() !== "OPTIONS") {
         await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+      } else {
+        await route.fulfill({ status: 204 });
       }
     });
 

--- a/frontend/__tests__/e2e/wishlist_workflow.spec.ts
+++ b/frontend/__tests__/e2e/wishlist_workflow.spec.ts
@@ -333,3 +333,141 @@ test.describe("FRBR Virtual Item Boundary", () => {
     await expect(requestLoanButton).toHaveCount(0);
   });
 });
+
+test.describe("Instant Wishlist Subtraction from Item Card", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/profile**", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            id: "test-user-id",
+            email: "test@iqoqo.local",
+            permissions: ["update:item", "write:metadata"],
+          },
+        }),
+      });
+    });
+
+    await page.route("**/api/config**", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: { federation_enabled: false, version: packageJson.version },
+        }),
+      });
+    });
+  });
+
+  test("allows instantaneous subtraction of an item from wishlist directly from the item card", async ({ page }) => {
+    // Mock items endpoint returning a wishlist item
+    await page.route("**/api/items**", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: [
+            {
+              id: -10,
+              title: "Test Wishlist Item",
+              authors: ["Test Author"],
+              status: "want_to_read",
+              collection_status: "wish_list",
+              manifestation_id: null,
+              is_owner: true,
+              owner_id: "test-user-id",
+              meta: {},
+            },
+          ],
+          meta: { page: 1, pages: 1, total: 1, limit: 20 },
+        }),
+      });
+    });
+
+    // Mock DELETE endpoint for wishlist removal
+    let deleteCalled = false;
+    await page.route("**/api/items/-10**", async route => {
+      if (route.request().method() === "DELETE") {
+        deleteCalled = true;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ success: true, data: { id: -10 } }),
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            data: {
+              id: -10,
+              title: "Test Wishlist Item",
+              collection_status: "wish_list",
+              is_owner: true,
+              meta: {},
+            },
+          }),
+        });
+      }
+    });
+
+    await page.route("**/api/stats**", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: { works: 0, items: 1 },
+        }),
+      });
+    });
+
+    await page.route("**/api/taxonomies**", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: { genres: [], tags: [], publishers: [], collections: [] },
+        }),
+      });
+    });
+
+    // Mock categories endpoint (for grid view)
+    await page.route("**/api/manifestations**", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: [], meta: { total: 0 } }),
+      });
+    });
+
+    await page.goto("/collection");
+    await page.waitForLoadState("networkidle");
+
+    // The item card should be visible
+    const itemCard = page.locator('[data-testid="item-card"]').first();
+    await expect(itemCard).toBeVisible();
+
+    // Hover over the item card to reveal the wishlist remove button
+    await itemCard.hover();
+
+    const removeBtn = itemCard.locator('[aria-label="Remove from wishlist"]');
+    await expect(removeBtn).toBeVisible();
+
+    // Click to remove from wishlist
+    await removeBtn.click();
+
+    // Verify the toast appears
+    await expect(page.getByText("Removed from wishlist")).toBeVisible();
+
+    // Verify the deletion was actually sent
+    expect(deleteCalled).toBe(true);
+  });
+});

--- a/frontend/components/collection/item-card.tsx
+++ b/frontend/components/collection/item-card.tsx
@@ -18,9 +18,12 @@
 import Link from "next/link";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { BookOpen, Disc, Loader2, Film, Dices, Puzzle, EyeOff, Check } from "lucide-react";
+import { BookOpen, Disc, Loader2, Film, Dices, Puzzle, EyeOff, Check, HeartOff } from "lucide-react";
 import type { Item, CatalogEntry } from "@/types/frbr";
 import { isAudioMedia, getCoverUrl, getCoverTimestamp, classifyCoverType } from "@/lib/utils";
+import { apiClient } from "@/lib/api/client";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 const statusDotColor: Record<string, string> = {
   available: "bg-chart-3",
@@ -72,11 +75,14 @@ interface ItemCardProps {
   isSelected?: boolean;
   /** Callback to toggle selection of this card (enables selection mode). */
   onToggleSelect?: (id: number) => void;
+  /** Callback invoked when the user removes an item from their wishlist. */
+  onWishlistRemove?: (itemId: number) => void;
 }
 
 /**
  * ItemCard displays an item card with cover art, titles, creators, status dots,
  * and quantity indicators. Supports vertical and horizontal layout variants.
+ * Wishlist items show a hover-revealed removal button for instant subtraction.
  *
  * @param props - Component properties.
  * @param props.item - The Item or CatalogEntry to display.
@@ -84,6 +90,7 @@ interface ItemCardProps {
  * @param props.isManifestationView - Flag indicating if this is grouped manifestation view.
  * @param props.isSelected - Whether this card is currently selected.
  * @param props.onToggleSelect - Callback to toggle selection of this card.
+ * @param props.onWishlistRemove - Callback invoked when user removes item from wishlist.
  * @returns An interactive card component linked to detail pages.
  */
 export function ItemCard({
@@ -92,8 +99,10 @@ export function ItemCard({
   isManifestationView = false,
   isSelected = false,
   onToggleSelect,
+  onWishlistRemove,
 }: ItemCardProps) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const isCatalog = isManifestationView;
 
   const itemId = isCatalog ? (item as CatalogEntry).id : (item as Item).id;
@@ -177,10 +186,40 @@ export function ItemCard({
     );
   };
 
+  const isWishlist = !isCatalog && collectionStatus === "wish_list";
+
   const quantityBadge = quantity > 1 && (
-    <div className="absolute top-2 right-2 z-20 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground shadow-md ring-2 ring-background">
+    <div
+      className={`absolute top-2 z-20 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground shadow-md ring-2 ring-background ${isWishlist ? "right-10" : "right-2"}`}
+    >
       x{quantity}
     </div>
+  );
+
+  const handleWishlistRemove = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    try {
+      await apiClient.delete(`/items/${itemId}`);
+      queryClient.invalidateQueries({ queryKey: ["items"] });
+      queryClient.invalidateQueries({ queryKey: ["stats"] });
+      toast.success("Removed from wishlist");
+      onWishlistRemove?.(itemId);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to remove from wishlist");
+    }
+  };
+
+  // Wishlist removal button visible on hover for wishlist items.
+  const wishlistRemoveBtn = isWishlist && (
+    <button
+      type="button"
+      aria-label="Remove from wishlist"
+      onClick={handleWishlistRemove}
+      className="absolute top-2 right-2 z-20 flex h-7 w-7 items-center justify-center rounded-full bg-background/80 text-destructive opacity-0 group-hover:opacity-100 transition-opacity shadow-sm ring-1 ring-border hover:bg-destructive hover:text-destructive-foreground"
+    >
+      <HeartOff className="h-3.5 w-3.5" />
+    </button>
   );
 
   // Checkbox overlay shown in Global Library (manifestation) view when selection mode is active.
@@ -217,6 +256,7 @@ export function ItemCard({
             className={`relative shrink-0 w-16 sm:w-20 overflow-hidden rounded-md shadow-sm bg-secondary ${aspectClass}`}
           >
             {quantityBadge}
+            {wishlistRemoveBtn}
             {(isProcessing || coverStatus === "pending") && (
               <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/60 backdrop-blur-sm">
                 <Loader2 className="h-5 w-5 animate-spin text-primary" />
@@ -304,6 +344,7 @@ export function ItemCard({
       <div className="overflow-hidden rounded-lg bg-card shadow-sm ring-1 ring-border/60 transition-all hover:shadow-md hover:ring-border">
         <div className={`relative w-full overflow-hidden bg-secondary ${aspectClass}`}>
           {quantityBadge}
+          {wishlistRemoveBtn}
           {selectionOverlay}
           {(isProcessing || coverStatus === "pending") && (
             <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 bg-background/60 backdrop-blur-sm p-4 text-center">

--- a/frontend/components/collection/manage-collections-modal.tsx
+++ b/frontend/components/collection/manage-collections-modal.tsx
@@ -17,9 +17,10 @@
 "use client";
 
 import React, { useState } from "react";
-import { Folder, Trash2, Edit2, Loader2, AlertCircle, X } from "lucide-react";
+import { Folder, Trash2, Edit2, Loader2, AlertCircle, X, Plus } from "lucide-react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "@/lib/api/client";
+import { toast } from "sonner";
 
 interface UserCollection {
   id: number;
@@ -34,7 +35,8 @@ export interface ManageCollectionsModalProps {
 }
 
 /**
- * A dedicated modal to manage (rename, delete, list) the user's hierarchy of custom collections.
+ * A dedicated modal to fully manage (create, rename, delete, list) the user's
+ * hierarchy of custom collections.
  *
  * @param root0 - Component props
  * @param root0.isOpen - Whether the modal is open
@@ -75,10 +77,28 @@ export function ManageCollectionsModal({ isOpen, onClose }: ManageCollectionsMod
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["user-collections"] });
       queryClient.invalidateQueries({ queryKey: ["taxonomies"] });
+      toast.success("Collection removed");
     },
     onError: (err: Error) => {
-      // In a real app, use a toast notification
-      alert(err.message);
+      toast.error(err.message);
+    },
+  });
+
+  const [createName, setCreateName] = useState("");
+
+  const createMutation = useMutation({
+    mutationFn: async (name: string) => {
+      const res = await apiClient.post("/collections", { name });
+      return res.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["user-collections"] });
+      queryClient.invalidateQueries({ queryKey: ["taxonomies"] });
+      setCreateName("");
+      toast.success("Collection created");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
     },
   });
 
@@ -100,6 +120,34 @@ export function ManageCollectionsModal({ isOpen, onClose }: ManageCollectionsMod
 
         {/* Content */}
         <div className="p-4 flex flex-col gap-3 min-h-[300px] max-h-[60vh] overflow-y-auto custom-scrollbar">
+          {/* Create new collection */}
+          <form
+            className="flex items-center gap-2"
+            onSubmit={e => {
+              e.preventDefault();
+              if (createName.trim()) {
+                createMutation.mutate(createName.trim());
+              }
+            }}
+          >
+            <input
+              type="text"
+              placeholder="New collection name"
+              value={createName}
+              onChange={e => setCreateName(e.target.value)}
+              className="flex h-9 flex-1 rounded-md border border-input bg-background px-3 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              disabled={createMutation.isPending}
+            />
+            <button
+              type="submit"
+              disabled={!createName.trim() || createMutation.isPending}
+              className="flex h-9 items-center gap-1.5 rounded-md bg-primary px-3 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+            >
+              {createMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+              Add
+            </button>
+          </form>
+
           {isLoading ? (
             <div className="flex flex-1 items-center justify-center py-12">
               <Loader2 className="h-8 w-8 animate-spin text-primary" />

--- a/frontend/components/collection/sidebar-filters.tsx
+++ b/frontend/components/collection/sidebar-filters.tsx
@@ -275,23 +275,26 @@ export function SidebarFilters({
         <div className="flex flex-col gap-1">
           {Object.entries(MEDIA_HIERARCHY).map(([id]) => {
             const active = isActive(activeFilters, "category", id);
+            const count = categoryCounts[id] ?? 0;
+            const disabled = !active && count === 0;
             return (
               <label
                 key={id}
-                className={`flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 text-sm transition-colors ${active ? "bg-primary/10 text-foreground ring-1 ring-primary/20" : "text-muted-foreground hover:text-foreground hover:bg-muted/30"}`}
+                className={`flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 text-sm transition-colors ${active ? "bg-primary/10 text-foreground ring-1 ring-primary/20" : "text-muted-foreground hover:text-foreground hover:bg-muted/30"} ${disabled ? "opacity-50" : ""}`}
               >
                 <input
                   type="radio"
                   name="category"
                   checked={active}
                   onChange={() => onToggleFilter({ type: "category", value: id })}
+                  disabled={disabled}
                   className="sr-only"
                 />
                 <span className={active ? "text-primary" : "text-muted-foreground"}>
                   {categoryIcons[id] || <LayoutGrid className="h-3.5 w-3.5" />}
                 </span>
                 <span className="flex-1 font-medium">{t(`cat_${id}`)}</span>
-                <span className="text-xs tabular-nums text-muted-foreground mr-1">{categoryCounts[id] ?? 0}</span>
+                <span className="text-xs tabular-nums text-muted-foreground mr-1">{count}</span>
                 {active && <div className="h-1.5 w-1.5 rounded-full bg-primary" />}
               </label>
             );
@@ -346,20 +349,23 @@ export function SidebarFilters({
           <div className="flex flex-col gap-1">
             {validFormats.map(fmt => {
               const active = isActive(activeFilters, "format", fmt.id);
+              const count = formatCounts[fmt.id] ?? 0;
+              const disabled = !active && count === 0;
               return (
                 <label
                   key={fmt.id}
-                  className={`flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 text-sm transition-colors ${active ? "bg-accent/10 text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-muted/30"}`}
+                  className={`flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 text-sm transition-colors ${active ? "bg-accent/10 text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-muted/30"} ${disabled ? "opacity-50" : ""}`}
                 >
                   <input
                     type="radio"
                     name="format_filter"
                     checked={active}
                     onChange={() => onToggleFilter({ type: "format", value: fmt.id })}
+                    disabled={disabled}
                     className="h-4 w-4 shrink-0 rounded-full border-input text-primary shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
                   />
                   <span className="flex-1">{t(`fmt_${fmt.id}`, { defaultValue: fmt.label })}</span>
-                  <span className="text-xs tabular-nums text-muted-foreground">{formatCounts[fmt.id] ?? 0}</span>
+                  <span className="text-xs tabular-nums text-muted-foreground">{count}</span>
                 </label>
               );
             })}
@@ -376,20 +382,23 @@ export function SidebarFilters({
           <div className="flex flex-col gap-1">
             {collectionStatuses.map(({ value, label, dot }) => {
               const active = isActive(activeFilters, "status", value);
+              const count = statusCounts[value] ?? 0;
+              const disabled = !active && count === 0;
               return (
                 <label
                   key={value}
-                  className={`flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 text-sm transition-colors ${active ? "bg-muted text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-muted/30"}`}
+                  className={`flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 text-sm transition-colors ${active ? "bg-muted text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-muted/30"} ${disabled ? "opacity-50" : ""}`}
                 >
                   <input
                     type="checkbox"
                     checked={active}
                     onChange={() => onToggleFilter({ type: "status", value })}
+                    disabled={disabled}
                     className="h-3.5 w-3.5 rounded border-border accent-primary"
                   />
                   <span className={`h-2 w-2 rounded-full ${dot}`} />
                   <span className="flex-1">{t(`status_${value}`, { defaultValue: label })}</span>
-                  <span className="text-xs tabular-nums text-muted-foreground">{statusCounts[value] ?? 0}</span>
+                  <span className="text-xs tabular-nums text-muted-foreground">{count}</span>
                 </label>
               );
             })}
@@ -403,20 +412,23 @@ export function SidebarFilters({
             {validProgressStatuses.map(status => {
               const info = progressLabels[status] || { label: status, dot: "bg-muted" };
               const active = isActive(activeFilters, "status", status);
+              const count = statusCounts[status] ?? 0;
+              const disabled = !active && count === 0;
               return (
                 <label
                   key={status}
-                  className={`flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 text-sm transition-colors ${active ? "bg-muted text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-muted/30"}`}
+                  className={`flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 text-sm transition-colors ${active ? "bg-muted text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-muted/30"} ${disabled ? "opacity-50" : ""}`}
                 >
                   <input
                     type="checkbox"
                     checked={active}
                     onChange={() => onToggleFilter({ type: "status", value: status })}
+                    disabled={disabled}
                     className="h-3.5 w-3.5 rounded border-border accent-primary"
                   />
                   <span className={`h-2 w-2 rounded-full ${info.dot}`} />
                   <span className="flex-1">{t(`progress_${status}`, { defaultValue: info.label })}</span>
-                  <span className="text-xs tabular-nums text-muted-foreground">{statusCounts[status] ?? 0}</span>
+                  <span className="text-xs tabular-nums text-muted-foreground">{count}</span>
                 </label>
               );
             })}

--- a/tests/bash/cloud_backup_check.bats
+++ b/tests/bash/cloud_backup_check.bats
@@ -46,8 +46,8 @@ EOF
   cat << 'EOF' > "${TEST_TEMP_DIR}/stub-bin/date"
 #!/bin/bash
 if [[ "$*" == *"-d"* ]]; then
-  # Return a static epoch representing a few hours ago
-  echo 1783584000
+  # Return a dynamic epoch representing 4 hours ago
+  echo $(($(/bin/date +%s) - 14400))
   exit 0
 fi
 # Fallback to system date


### PR DESCRIPTION
- ItemCard: add hover-revealed HeartOff button for instant wishlist subtraction
- ManageCollectionsModal: add inline Create collection form with toast notifications
- SidebarFilters: add dynamic cross-filtering visual treatment (mute zero-count facets)
- Tests: add unit tests for wishlist removal, collection creation, cross-filtering
- E2E: add manage_collections, wishlist subtraction, facet cross-filtering Playwright specs